### PR TITLE
Refactored Documentation according to Matic Mumbai Testnet Configuration and Updated Broken Link of Deployed Contracts

### DIFF
--- a/docs/Contracts/p1- Intro.md
+++ b/docs/Contracts/p1- Intro.md
@@ -1,7 +1,7 @@
 # Introduction
 The contracts can be found in our github repo [here](https://github.com/razor-network/contracts)
 
-The addresses where the contracts are deployed can be found [here](https://github.com/razor-network/contracts/blob/master/ADDRESSES.md)
+The addresses where the contracts are deployed can be found [here](https://github.com/razor-network/contracts/blob/master/deployed/matic/addresses.json)
 
 The different kinds of contracts and their functions:
 

--- a/docs/Quick Start/Stake.md
+++ b/docs/Quick Start/Stake.md
@@ -2,22 +2,20 @@
 
 Razor network is a proof of stake network. In order to participate in the network as a validator, you will need to "Stake" your RAZORs. RAZORs are the native tokens in the network and they are compatible with the ERC20 tokens standard.
 
-> Warning: Razor network is in alpha state and is deployed on görli testnet. Please don't use assets with value.
+> Warning: Razor network is in alpha state and is deployed on Matic Mumbai testnet. Please don't use assets with value.
 
 ##Get tokens
 
-You will need some görli ether to pay for transaction fees.
+You will need some MATIC Tokens to pay for transaction fees.
 
 You can get some here:
 
-1. [https://goerli-faucet.slock.it/](https://goerli-faucet.slock.it/)
+1. [https://faucet.matic.network/](https://faucet.matic.network/)
 
-2. OR [https://faucet.goerli.mudit.blog/](https://faucet.goerli.mudit.blog/)
-
-In order to get started, you will also need some Görli RAZORs.
+In order to get started, you will also need some MATIC RAZORs.
 
 1. Use an ethereum compatible browser (e.g. Chrome browser with Metamask plugin)
-2. Set the network to "Görli testnet" in Metamask
+2. Set the network to "Matic Mumbai Testnet" in Metamask
 3. Go to [https://razorscan.io/#/faucet](https://razorscan.io/#/faucet)
 4. Paste your ethereum address in the address field.
 5. Click "Get RAZOR"
@@ -61,7 +59,7 @@ In future we will provide a docker container to make things easier.
 
     `ls keys`
 
-3. Send your RAZORs and görli ether to this address.
+3. Send your RAZORs and MATICs to this address.
 
 ## Stake
 1. Stake RAZORs using this command

--- a/docs/Quick Start/usage.md
+++ b/docs/Quick Start/usage.md
@@ -1,5 +1,5 @@
 # Use the Oracle
-Razor network is currently live on Görli Ethereum testnet. So you can deploy your applications on Görli and use Razor to fetch data for your applications.
+Razor network is currently live on Matic Mumbai testnet. So you can deploy your applications on Matic and use Razor to fetch data for your applications.
 
 ## Create a new query
 You can currently make two kinds of queries on Razor.
@@ -10,8 +10,8 @@ You can currently make two kinds of queries on Razor.
 ### Create a datafeed query using RazorScan
 RazorScan provides an easy to use GUI to create datafeed queries on Razor Easily.
 
-1. Make sure you are using a ethereum compatible browser (e.g. Chrome + Metamask) and set the network to Görli testnet.
-2. You will need some Görli ether to pay for transaction fees.
+1. Make sure you are using a ethereum compatible browser (e.g. Chrome + Metamask) and set the network to Matic Mumbai testnet.
+2. You will need some Matic tokens to pay for transaction fees.
 3. Go to [https://razorscan.io/#/query](https://razorscan.io/#/query) and enter a URL which reponds with a JSON formatted data
 2. Enter a JSON Selector
 3. Enter the name of the datafeed
@@ -24,7 +24,7 @@ RazorScan provides an easy to use GUI to create datafeed queries on Razor Easily
 You can create the datafeed programmatically as well by interacting with the Job Manager contract.
 The source code for job manager can be found here: [JobManager.sol](https://github.com/razor-network/contracts/blob/master/contracts/Core/JobManager.sol)
 
-The Address of the job manager contract can be found [here](https://github.com/razor-network/contracts/blob/master/ADDRESSES.md)
+The Address of the job manager contract can be found [here](https://github.com/razor-network/contracts/blob/master/deployed/matic/addresses.json)
 
 Note: Currently creating queries on Razor is free of cost.
 
@@ -35,4 +35,4 @@ You can access the proxy delegator contract to get the results of the datafeeds.
 1. You will need to know the "Job ID" of your query. You can go to [https://razorscan.io/#/custom](https://razorscan.io/#/custom) and select your query to know the Job ID of your query.
 2. You can call the "getResult" method of Delegator to get latest result of your query. The source of the contract is here : [Delegator.sol](https://github.com/razor-network/contracts/blob/master/contracts/Delegator.sol)
 3. You can alternatively call "getJob" method of the same contract to get more information about the query such as name, url, selector, etc.
-4. The address of the delegator contract can be found [here](https://github.com/razor-network/contracts/blob/master/ADDRESSES.md)
+4. The address of the delegator contract can be found [here](https://github.com/razor-network/contracts/blob/master/deployed/matic/addresses.json)


### PR DESCRIPTION
I have made changes in documentation according to Matc Mumbai Testnet Configuration. Resolves #14